### PR TITLE
Add GitHub Skills activity to course offerings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -76,7 +76,7 @@ activities = {
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     },
     "GitHub Skills": {
-        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
         "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
         "max_participants": 25,
         "participants": []

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal in the school assembly.

## Changes Made
- ✅ Added "GitHub Skills" activity to the activities dictionary
- ✅ Set capacity at 25 participants to accommodate high demand
- ✅ Scheduled for Tuesdays, 3:30 PM - 5:00 PM
- ✅ Description mentions GitHub Certifications program and college application benefits

## Issue Addressed
Fixes #6 

## Context
Students have been unable to sign up for this activity despite the official announcement. This is **time-sensitive** as registrations close by the end of this week. The activity is part of the GitHub Certifications program which will help students with college applications.

## Testing
- [ ] Verify activity appears in the activity list
- [ ] Confirm students can register for GitHub Skills
- [ ] Check that max_participants (25) is enforced

## Notes
This implements the highest priority issue from our backlog to address the urgent need for student registrations.